### PR TITLE
chore: release v0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1](https://github.com/kofta999/pryr/compare/v0.5.0...v0.5.1) - 2026-03-19
+
+### Fixed
+
+- updates on windows
+
 ## [0.5.0](https://github.com/kofta999/pryr/compare/v0.4.5...v0.5.0) - 2026-03-19
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1558,7 +1558,7 @@ dependencies = [
 
 [[package]]
 name = "pryr"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pryr"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 license = "MIT"
 description = "A blazing-fast, uncompromising Islamic prayer time daemon and screen locker for Linux and Windows"


### PR DESCRIPTION



## 🤖 New release

* `pryr`: 0.5.0 -> 0.5.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.5.1](https://github.com/kofta999/pryr/compare/v0.5.0...v0.5.1) - 2026-03-19

### Fixed

- updates on windows
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).